### PR TITLE
feat: include method loadClientWithProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,11 @@ export const loadClientAuth2: (
   scopes: string
 ) => Promise<gapi.auth2.GoogleAuth>;
 
+export const loadClientWithProps: (
+  gapiScript: typeof gapi,
+  props: any,
+) => Promise<gapi>;
+
 export const loadGapiInsideDOM: () => Promise<typeof gapi>;
 
 export const gapiComplete: any;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { gapi, gapiComplete } from './gapiScript';
+import { gapi, gapiComplete } from './gapiScript'
 
 /**
  * Function to load gapi auth2 from a gapi that you provied
@@ -13,9 +13,9 @@ const loadAuth2 = async function (gapiScript, clientId, scopes) {
       resolve(gapiScript.auth2.init({
         client_id: clientId,
         scope: scopes
-      }));
-    });
-  });
+      }))
+    })
+  })
 }
 
 /**
@@ -26,9 +26,9 @@ const loadAuth2 = async function (gapiScript, clientId, scopes) {
 const loadAuth2WithProps = async function (gapiScript, props) {
   return new Promise(resolve => {
     gapiScript.load('auth2', () => {
-      resolve(gapiScript.auth2.init(props));
-    });
-  });
+      resolve(gapiScript.auth2.init(props))
+    })
+  })
 }
 
 /**
@@ -39,19 +39,34 @@ const loadAuth2WithProps = async function (gapiScript, props) {
  */
 const loadClientAuth2 = async function (gapiScript, clientId, scopes) {
   return new Promise(resolve => {
-      gapiScript.load('client', () => {
-          resolve(gapiScript.client.init({
-              client_id: clientId,
-              scope: scopes
-          }));
-      });
-      gapiScript.load('auth2', () => {
-          resolve(gapiScript.client.init({
-              client_id: clientId,
-              scope: scopes
-          }));
-      });
-  });
+    gapiScript.load('client', () => {
+      resolve(gapiScript.client.init({
+        client_id: clientId,
+        scope: scopes
+      }))
+    })
+    gapiScript.load('auth2', () => {
+      resolve(gapiScript.client.init({
+        client_id: clientId,
+        scope: scopes
+      }))
+    })
+  })
+}
+
+
+
+/**
+ * Function to init gapi client with props
+ * @param {Object} gapiScript gapi script object
+ * @param {*} props Possible props to init gapi client, check the options on google docs: https://github.com/google/google-api-javascript-client/
+ */
+const loadClientWithProps = async function (gapiScript, props) {
+  return new Promise(resolve => {
+    gapiScript.load('client', () => {
+      resolve(gapiScript.client.init(props))
+    })
+  })
 }
 
 /**
@@ -62,17 +77,17 @@ const loadClientAuth2 = async function (gapiScript, clientId, scopes) {
  */
 const loadGapiInsideDOM = async function () {
   return new Promise(resolve => {
-    const element = document.getElementsByTagName('script')[0];
-    const js = document.createElement('script');
-    js.id = 'google-platform';
-    js.src = '//apis.google.com/js/platform.js';
-    js.async = true;
-    js.defer = true;
-    element.parentNode.insertBefore(js, element);
+    const element = document.getElementsByTagName('script')[0]
+    const js = document.createElement('script')
+    js.id = 'google-platform'
+    js.src = '//apis.google.com/js/platform.js'
+    js.async = true
+    js.defer = true
+    element.parentNode.insertBefore(js, element)
     js.onload = async () => {
-      resolve(window.gapi);
+      resolve(window.gapi)
     }
-  });
+  })
 }
 
 export {
@@ -81,5 +96,6 @@ export {
   loadAuth2,
   loadAuth2WithProps,
   loadClientAuth2,
+  loadClientWithProps,
   loadGapiInsideDOM,
-};
+}


### PR DESCRIPTION
Hi, 

First of all, thanks for this awesome lib, it helped me to understand how to use the gapi. 

I made this modification so I could pass the discoveryDocs prop like this: 
```javascript
await loadClientWithProps(gapi, {
  apiKey: process.env.REACT_APP_API_KEY,
  discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest']
})
```

and then gain acces to the gapi.client.drive (or other apis) like this: 
```javascript
await window.gapi.client.drive.files.list({
  'fields': 'files(id, name)'
})
``` 

It worked just great. 